### PR TITLE
Clarify openat()+write() calls that are allowed for certain modules

### DIFF
--- a/modules/file/file.go
+++ b/modules/file/file.go
@@ -72,9 +72,10 @@ func init() {
 					"openat",
 					"stat",
 					"readlinkat",
+					// UNSAFE openat() with write() - we shouldn't be able to call write() in the file module but is currently needed for things to work
 					"write",
-					"mmap",            // GO
-					"futex",           // GO
+					"mmap",  // GO
+					"futex", // GO
 					"getdents64",
 					"read",
 					"sigaltstack",     // GO
@@ -84,8 +85,8 @@ func init() {
 					"sched_yield",     // GO
 
 					// Used for pretty printing the violating syscall (rare)
-					"exit_group",      // Sandbox
-					"rt_sigreturn",    // Sandbox
+					"exit_group",   // Sandbox
+					"rt_sigreturn", // Sandbox
 				},
 				Action: sandbox.ActAllow,
 			},

--- a/modules/ping/ping.go
+++ b/modules/ping/ping.go
@@ -54,6 +54,7 @@ func init() {
 					"futex",
 					"getsockname",
 					"getpeername",
+					// UNSAFE openat() with write() - we shouldn't be able to call write() in the file module but is currently needed for things to work
 					"write",
 					"epoll_wait",
 					"read",

--- a/modules/timedrift/timedrift.go
+++ b/modules/timedrift/timedrift.go
@@ -46,6 +46,7 @@ func init() {
 				FilterOn: []string{
 					"select",
 					"futex",
+
 					"write",
 					"read",
 					"epoll_ctl",


### PR DESCRIPTION
Solving some of the comments in the PR

https://github.com/mozilla/mig/pull/164/files
